### PR TITLE
Alias test execution on package setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,6 @@ install:
 script: pytest
 branches:
   only:
+    - alias-setup-tests
     - dev
     - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,5 @@ install:
 script: pytest
 branches:
   only:
-    - alias-setup-tests
     - dev
     - master

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,10 +1,7 @@
 [pytest]
-; Get additional test summary information, retaining ordinary dot notation.
-; Here, we request additional information for every status except pass.
-addopts = -rfE
 ; Test discovery process, matching tests directory
 ; Also restrict test discovery to patterned modules, classes, and functions.
-testpaths = tests
 python_files = test_*.py
 python_classes = Test* *Test *Tests *Tester
 python_functions = test_* test[A-Z]*
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,8 @@
+[pytest]
+; Get additional test summary information, retaining ordinary dot notation.
+; Here, we request additional information for every status except pass.
+addopts = -rfE
+
+[aliases]
+test = pytest
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,5 @@
 [pytest]
-; Get additional test summary information, retaining ordinary dot notation.
-; Here, we request additional information for every status except pass.
+# Only request extra info from failures and errors.
 addopts = -rfE
 
 [aliases]

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
     test_suite="tests",
     tests_require=["pytest"],
     setup_requires=(["pytest-runner"]
-                    if {"ptr", "test", "tests", "pytest"} & set(sys.argv)
+                    if {"ptr", "test", "pytest"} & set(sys.argv)
                     else []),
     **extra
 )


### PR DESCRIPTION
Rather than requiring users to run `python setup.py pytest`, allow the more familiar `python setup.py test` command to trigger `pytest` just the same.