### PR TITLE
Implied columns tests and messaging

### DIFF
--- a/looper/__init__.py
+++ b/looper/__init__.py
@@ -41,7 +41,6 @@ def setup_looper_logger(level, additional_locations=None, devmode=False):
     :return logging.Logger: project-root logger
     """
 
-    logging.addLevelName(0, "EVERYTHING")
     logging.addLevelName(5, "VERY_FINE")
 
     fmt = DEV_LOGGING_FMT if devmode else DEFAULT_LOGGING_FMT

--- a/looper/models.py
+++ b/looper/models.py
@@ -1302,6 +1302,10 @@ class Sample(object):
             return
 
         impliers = self.prj[IMPLICATIONS_DECLARATION]
+
+        # DEBUG
+        print("IMPLIERS: {}".format(impliers))
+
         _LOGGER.debug(
                 "Sample variable(s) that can imply others: %s", str(impliers))
         for implier_name, implied in impliers.items():
@@ -1309,11 +1313,19 @@ class Sample(object):
                 "Setting Sample variable(s) implied by '%s'", implier_name)
             try:
                 implier_value = self[implier_name]
+
+                # DEBUG
+                print("Got {} for {}".format(implier_value, implier_name))
+
             except KeyError:
                 _LOGGER.debug("No '%s' for this sample", implier_name)
                 continue
             try:
                 implied_value_by_column = implied[implier_value]
+
+                # DEBUG
+                print("Got implied_value_by_column: {}".format(implied_value_by_column))
+
                 _LOGGER.debug("Implications for '%s' = %s: %s",
                               implier_name, implier_value,
                               str(implied_value_by_column))

--- a/looper/models.py
+++ b/looper/models.py
@@ -1303,9 +1303,6 @@ class Sample(object):
 
         impliers = self.prj[IMPLICATIONS_DECLARATION]
 
-        # DEBUG
-        print("IMPLIERS: {}".format(impliers))
-
         _LOGGER.debug(
                 "Sample variable(s) that can imply others: %s", str(impliers))
         for implier_name, implied in impliers.items():
@@ -1313,19 +1310,11 @@ class Sample(object):
                 "Setting Sample variable(s) implied by '%s'", implier_name)
             try:
                 implier_value = self[implier_name]
-
-                # DEBUG
-                print("Got {} for {}".format(implier_value, implier_name))
-
             except KeyError:
                 _LOGGER.debug("No '%s' for this sample", implier_name)
                 continue
             try:
                 implied_value_by_column = implied[implier_value]
-
-                # DEBUG
-                print("Got implied_value_by_column: {}".format(implied_value_by_column))
-
                 _LOGGER.debug("Implications for '%s' = %s: %s",
                               implier_name, implier_value,
                               str(implied_value_by_column))

--- a/looper/models.py
+++ b/looper/models.py
@@ -1044,8 +1044,11 @@ class Sample(object):
         # appending new columns onto the original table)
         self.sheet_attributes = series.keys()
 
+        if isinstance(series, _pd.Series):
+            series = series.to_dict()
+
         # Set series attributes on self.
-        for key, value in series.to_dict().items():
+        for key, value in series.items():
             setattr(self, key, value)
 
         # Check if required attributes exist and are not empty.
@@ -1265,7 +1268,7 @@ class Sample(object):
             impliers = self.prj["implied_columns"]
             _LOGGER.debug("%s variables that can imply others: %s", 
                           self.__class__.__name, str(impliers))
-            for implier_name, implied_data_by_implier_value in impliers.items():
+            for implier_name, implied in impliers.items():
                 _LOGGER.debug(
                         "Setting %s variable(s) implied by '%s'",
                         self.__class__.__name__, implier_name)
@@ -1275,9 +1278,10 @@ class Sample(object):
                     _LOGGER.debug("No '%s' for this sample", implier_name)
                     continue
                 try:
-                    implied_value_by_column = \
-                            implied_data_by_implier_value[implier_value]
-                    _LOGGER.debug(implied_data_by_implier_value[implier_value])
+                    implied_value_by_column = implied[implier_value]
+                    _LOGGER.debug("Implications for '%s' = %s: %s",
+                                  implier_name, implier_value,
+                                  str(implied_value_by_column))
                     for colname, implied_value in \
                             implied_value_by_column.items():
                         _LOGGER.log(5, "Setting '%s'=%s",

--- a/looper/models.py
+++ b/looper/models.py
@@ -174,7 +174,7 @@ class AttributeDict(MutableMapping):
         :param collections.Iterable | collections.Mapping entries: collection
             of pairs of keys and values
         """
-        self._log_(5, "Adding entries {}".format(entries))
+        _LOGGER.log(5, "Adding entries {}".format(entries))
         # Permit mapping-likes and iterables/generators of pairs.
         if callable(entries):
             entries = entries()
@@ -225,27 +225,26 @@ class AttributeDict(MutableMapping):
         :raises AttributeDict.MetadataOperationException: if attempt is made
             to set value for privileged metadata key
         """
-        self._log_(5, "Executing __setitem__ for '{}', '{}'".
-                   format(key, str(value)))
+        _LOGGER.log(5, "Executing __setitem__ for '{}', '{}'".
+                    format(key, str(value)))
         if isinstance(value, Mapping):
             try:
                 # Combine AttributeDict instances.
-                self._log_(logging.DEBUG, "Updating key: '{}'".format(key))
+                _LOGGER.debug("Updating key: '{}'".format(key))
                 self.__dict__[key].add_entries(value)
             except (AttributeError, KeyError):
                 # Create new AttributeDict, replacing previous value.
                 self.__dict__[key] = AttributeDict(value)
-            self._log_(logging.DEBUG, "'{}' now has keys {}".
-                       format(key, self.__dict__[key].keys()))
+            _LOGGER.debug("'{}' now has keys {}".
+                          format(key, self.__dict__[key].keys()))
         elif value is not None or \
                 key not in self.__dict__ or self.__dict__["_force_nulls"]:
-            self._log_(5, "Setting '{}' to {}".format(key, value))
+            _LOGGER.log(5, "Setting '{}' to {}".format(key, value))
             self.__dict__[key] = value
         else:
-            self._log_(logging.DEBUG,
-                       "Not setting {k} to {v}; _force_nulls: {nulls}".
-                       format(k=key, v=value,
-                              nulls=self.__dict__["_force_nulls"]))
+            _LOGGER.debug("Not setting {k} to {v}; _force_nulls: {nulls}".
+                          format(k=key, v=value,
+                                 nulls=self.__dict__["_force_nulls"]))
 
 
     def __getitem__(self, item):
@@ -263,7 +262,7 @@ class AttributeDict(MutableMapping):
         try:
             del self.__dict__[item]
         except KeyError:
-            self._log_(logging.DEBUG, "No item {} to delete".format(item))
+            _LOGGER.debug("No item {} to delete".format(item))
 
     def __eq__(self, other):
         for k in iter(self):
@@ -284,9 +283,6 @@ class AttributeDict(MutableMapping):
 
     def __repr__(self):
         return repr(self.__dict__)
-
-    def _log_(self, level, message):
-        _LOGGER.log(level, message)
 
 
 

--- a/looper/models.py
+++ b/looper/models.py
@@ -73,8 +73,11 @@ from .utils import \
     bam_or_fastq, check_bam, check_fastq, get_file_size, partition
 
 
+IMPLICATIONS_DECLARATION = "implied_columns"
 COL_KEY_SUFFIX = "_key"
+
 ATTRDICT_METADATA = ("_force_nulls", "_attribute_identity")
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -1295,10 +1298,10 @@ class Sample(object):
         
         :return None: this function mutates state and is strictly for effect
         """
-        if not hasattr(self.prj, "implied_columns"):
+        if not hasattr(self.prj, IMPLICATIONS_DECLARATION):
             return
 
-        impliers = self.prj["implied_columns"]
+        impliers = self.prj[IMPLICATIONS_DECLARATION]
         _LOGGER.debug(
                 "Sample variable(s) that can imply others: %s", str(impliers))
         for implier_name, implied in impliers.items():

--- a/requirements/requirements-test.txt
+++ b/requirements/requirements-test.txt
@@ -1,2 +1,3 @@
 coveralls==1.1
+mock==2.0.0
 pytest-cov==2.4.0

--- a/tests/interactive.py
+++ b/tests/interactive.py
@@ -4,10 +4,7 @@
 # cd $CODEBASE/looper/tests
 # ipython
 
-from __future__ import absolute_import
-import looper
-#from . import conftest
 import conftest
 
-print("Running interactive.py tests")
+print("Establishing Project and PipelineInterface for testing and exploration")
 proj, pi = conftest.interactive()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -608,9 +608,8 @@ class ParseSampleImplicationsTests:
 
 
 
-class SampleMinimumInputTests:
-    """ Test minimal input and formats to create a Sample. """
-
+class SampleHodgepodgeTests:
+    """ One-off sorts of Sample tests. """
 
     @pytest.mark.parametrize(
             argnames="data_type", argvalues=[dict, Series],
@@ -630,3 +629,22 @@ class SampleMinimumInputTests:
             with pytest.raises(ValueError):
                 Sample(data_type(data))
 
+
+    @pytest.mark.parametrize(
+            argnames="accessor", argvalues=["attr", "item"],
+            ids=lambda access_mode: "accessor={}".format(access_mode))
+    @pytest.mark.parametrize(argnames="data_type", argvalues=[dict, Series])
+    def test_exception_type(self, data_type, accessor):
+        """ Exception for attribute access failure reflects access mode. """
+        data = {"sample_name": "placeholder"}
+        sample = Sample(data_type(data))
+        if accessor == "attr":
+            with pytest.raises(AttributeError):
+                sample.undefined_attribute
+        elif accessor == "item":
+            with pytest.raises(KeyError):
+                sample["not-set"]
+        else:
+            # Personal safeguard against unexpected behavior
+            pytest.fail("Unknown access mode for exception type test: {}".
+                        format(accessor))

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -5,14 +5,13 @@ import itertools
 
 import mock
 import numpy as np
+from pandas import Series
 import pytest
 
 from .conftest import basic_entries, nested_entries, COMPARISON_FUNCTIONS
 import looper
 from looper.exceptions import MetadataOperationException
-from looper.models import \
-        AttributeDict, Paths, copy, \
-        ATTRDICT_METADATA, IMPLICATIONS_DECLARATION
+from looper.models import AttributeDict, Paths, Sample, copy, ATTRDICT_METADATA
 
 
 _ATTR_VALUES = [None, set(), [], {}, {"abc": 123}, (1, 'a'),
@@ -606,3 +605,28 @@ class ParseSampleImplicationsTests:
                         new=rubber_stamper):
             mocked_sample = looper.models.Sample(data)
         return mocked_sample
+
+
+
+class SampleMinimumInputTests:
+    """ Test minimal input and formats to create a Sample. """
+
+
+    @pytest.mark.parametrize(
+            argnames="data_type", argvalues=[dict, Series],
+            ids=lambda data_type: "data_type={}".format(data_type.__name__))
+    @pytest.mark.parametrize(
+            argnames="has_name", argvalues=[False, True],
+            ids=lambda has_name: "has_name: {}".format(has_name))
+    def test_requires_sample_name(self, has_name, data_type):
+        data = {}
+        sample_name_key = "sample_name"
+        sample_name = "test-sample"
+        if has_name:
+            data[sample_name_key] = sample_name
+            sample = Sample(data_type(data))
+            assert sample_name == getattr(sample, sample_name_key)
+        else:
+            with pytest.raises(ValueError):
+                Sample(data_type(data))
+

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -527,7 +527,6 @@ class ParseSampleImplicationsTests:
         assert before_inference == sample.__dict__
 
 
-    @pytest.mark.skip("Limit output")
     @pytest.mark.parametrize(
             argnames=["implier_value", "implications"],
             argvalues=zip(IMPLIER_VALUES, IMPLICATIONS),
@@ -542,9 +541,10 @@ class ParseSampleImplicationsTests:
         for implied_field_name in implications.keys():
             assert not hasattr(sample, implied_field_name)
 
-        sample.prj[IMPLICATIONS_DECLARATION] = self.IMPLICATIONS_MAP
         setattr(sample, self.IMPLIER_NAME, implier_value)
-        sample.infer_columns()
+        implications = mock.MagicMock(implied_columns=self.IMPLICATIONS_MAP)
+        with mock.patch.object(sample, "prj", create=True, new=implications):
+            sample.infer_columns()
 
         for implied_name, implied_value in implications.items():
             assert implied_value == getattr(sample, implied_name)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -530,9 +530,9 @@ class ParseSampleImplicationsTests:
     @pytest.mark.parametrize(
             argnames=["implier_value", "implications"],
             argvalues=zip(IMPLIER_VALUES, IMPLICATIONS),
-            ids=lambda (implier_value, implications):
-            "implier='{}', implications={}".format(implier_value,
-                                                   str(implications)))
+            ids=lambda implier_and_implications:
+            "implier='{}', implications={}".format(
+                implier_and_implications[0], str(implier_and_implications[1])))
     def test_intersection_between_sample_and_implications(
             self, sample, implier_value, implications):
         """ Intersection between implications and sample fields --> append. """

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -478,3 +478,10 @@ class PipelineInterfaceTests:
     def test_missing_input_files(self, proj):
         # This should not throw an error
         assert proj.samples[0].get_attr_values("all_input_files") is None
+
+
+
+@pytest.mark.skip("Not implemented")
+class ParseSampleImplicationsTests:
+    """ Tests for appending columns/fields to a Sample based on a mapping. """
+    pass

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,8 +2,11 @@
 
 from copy import deepcopy
 import itertools
+
+import mock
 import numpy as np
 import pytest
+
 from .conftest import basic_entries, nested_entries, COMPARISON_FUNCTIONS
 from looper.exceptions import MetadataOperationException
 from looper.models import AttributeDict, Paths, copy, ATTRDICT_METADATA
@@ -481,7 +484,48 @@ class PipelineInterfaceTests:
 
 
 
-@pytest.mark.skip("Not implemented")
 class ParseSampleImplicationsTests:
     """ Tests for appending columns/fields to a Sample based on a mapping. """
+
+    @pytest.fixture(scope="function")
+    def sample(self, request):
+        if "data" in request.fixturenames:
+            data = request.getfixturevalue("data")
+        else:
+            data = {}
+        name = "test-sample"
+        mocked_sample = mock.MagicMock(name=name, sample_name=name, **data)
+        return mocked_sample
+
+
+    def test_project_lacks_implications(self, sample):
+        """ With no implications mapping, sample is unmodified. """
+        before_inference = sample.__dict__
+        with mock.patch.object(sample, "prj"):
+            sample.infer_columns()
+        after_inference = sample.__dict__
+        assert before_inference == after_inference
+
+
+    def test_empty_implications(self, sample):
+        """ Empty implications mapping --> unmodified sample. """
+        pass
+
+    def test_null_intersection_between_sample_and_implications(self, sample):
+        """ Sample with none of implications' fields --> no change. """
+        pass
+
+    def test_intersection_between_sample_and_implications(self, sample):
+        """ Intersection between implications and sample fields --> append. """
+        pass
+
+    def test_sample_has_unmapped_value_for_implication(self, sample):
+        """ Unknown value in implier field --> null inference. """
+        pass
+
+
+
+@pytest.mark.skip("Not implemented")
+class SampleRequiredAttributesTests:
+    """ Tests for ensuring Sample's required attribute(s)' presence. """
     pass

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -487,15 +487,17 @@ class PipelineInterfaceTests:
 class ParseSampleImplicationsTests:
     """ Tests for appending columns/fields to a Sample based on a mapping. """
 
-    @pytest.fixture(scope="function")
-    def sample(self, request):
-        if "data" in request.fixturenames:
-            data = request.getfixturevalue("data")
-        else:
-            data = {}
-        name = "test-sample"
-        mocked_sample = mock.MagicMock(name=name, sample_name=name, **data)
-        return mocked_sample
+    IMPLICATIONS_DATA = {
+        "sample_name": {
+            "a": {
+                "genome": "hg38",
+                "phenome": "hg72"
+            },
+            "b": {
+                "genome": "hg38"
+            }
+        }
+    }
 
 
     def test_project_lacks_implications(self, sample):
@@ -509,19 +511,40 @@ class ParseSampleImplicationsTests:
 
     def test_empty_implications(self, sample):
         """ Empty implications mapping --> unmodified sample. """
-        pass
+        before_inference = sample.__dict__
+        project = mock.MagicMock(implied_columns={})
+        with mock.patch.object(sample, "prj", new=project):
+            sample.infer_columns()
+        assert before_inference == sample.__dict__
 
+
+    @pytest.mark.skip("Not implemented")
     def test_null_intersection_between_sample_and_implications(self, sample):
         """ Sample with none of implications' fields --> no change. """
         pass
 
+
+    @pytest.mark.skip("Not implemented")
     def test_intersection_between_sample_and_implications(self, sample):
         """ Intersection between implications and sample fields --> append. """
         pass
 
+
+    @pytest.mark.skip("Not implemented")
     def test_sample_has_unmapped_value_for_implication(self, sample):
         """ Unknown value in implier field --> null inference. """
         pass
+
+
+    @pytest.fixture(scope="function")
+    def sample(self, request):
+        if "data" in request.fixturenames:
+            data = request.getfixturevalue("data")
+        else:
+            data = {}
+        name = "test-sample"
+        mocked_sample = mock.MagicMock(name=name, sample_name=name, **data)
+        return mocked_sample
 
 
 


### PR DESCRIPTION
TL;DR --> adds implied columns parsing context and tests and slightly improves existing functionality.

This adds some context to the messaging around implied columns parsing. It also adds tests for this new feature. Along for the ride is the removal of the restriction to `Series` on type of input data to `Sample` constructor, and ensuring that exception type reflects the access mode for a `Sample` data item. That is, dot-notation produces `AttributeError` and getitem syntax produces `KeyError` when the name of the data item requested isn't defined for the `Sample` instance in question. There's a small handful of tests here for those changes as well. Other changes are stylistic.