### PR TITLE
Make skip occurrence report binary

### DIFF
--- a/looper/looper.py
+++ b/looper/looper.py
@@ -271,7 +271,6 @@ def run(prj, args, remaining_args, interface_manager):
                 fail_message = "Pipeline required attribute(s) missing."
                 _LOGGER.warn("> Not submitted: %s", fail_message)
                 skip_reasons.append(fail_message)
-                continue
 
             # Check for any required inputs before submitting
             try:
@@ -281,7 +280,6 @@ def run(prj, args, remaining_args, interface_manager):
                 fail_message = "Required input file(s) not found."
                 _LOGGER.warn("> Not submitted: %s", fail_message)
                 skip_reasons.append(fail_message)
-                continue
 
             # Identify cluster resources required for this submission.
             submit_settings = pipeline_interface.choose_resource_package(
@@ -310,8 +308,7 @@ def run(prj, args, remaining_args, interface_manager):
                                "for pipeline arguments string."
                 _LOGGER.warn("> Not submitted: %s", fail_message)
                 skip_reasons.append(fail_message)
-                continue
-                
+
             # Project-level arguments (sample-agnostic) are handled separately.
             argstring += prj.get_arg_string(pl_id)
             cmd += argstring
@@ -388,17 +385,18 @@ def aggregate_exec_skip_reasons(skip_reasons_sample_pairs):
     """
     Collect the reasons for skipping submission/execution of each sample 
     
-    :param skip_reasons_sample_pairs: 
+    :param Iterable[(Iterable[str], str)] skip_reasons_sample_pairs: pairs of 
+        collection of reasons for which a sample was skipped for submission, 
+        and the name of the sample itself
     :return Mapping[str, Iterable[str]]: mapping from explanation to 
         collection of names of samples to which it pertains
     """
     from collections import Counter, defaultdict
-    sample_count_pairs_by_skip_reason = defaultdict(list)
+    samples_by_skip_reason = defaultdict(list)
     for skip_reasons, sample in skip_reasons_sample_pairs:
-        for reason, num_skips in Counter(skip_reasons).items():
-            sample_count_pairs_by_skip_reason[reason].append(
-                    (sample, num_skips))
-    return sample_count_pairs_by_skip_reason
+        for reason in set(skip_reasons):
+            samples_by_skip_reason[reason].append(sample)
+    return samples_by_skip_reason
 
 
 

--- a/tests/test_looper.py
+++ b/tests/test_looper.py
@@ -352,7 +352,7 @@ class RunErrorReportTests:
                 this_sample_reasons = nprand.choice(
                     reasons, size=nprand.choice([1, 2]), replace=False)
                 for reason in this_sample_reasons:
-                    expected[reason].append((sample, 1))
+                    expected[reason].append(sample)
                 original_reasons.append((this_sample_reasons, sample))
 
             observed = aggregate_exec_skip_reasons(original_reasons)
@@ -360,7 +360,7 @@ class RunErrorReportTests:
 
 
     def test_same_skip_same_sample(self):
-        """ We count pipeline skips of each sample by reason. """
+        """ Multiple submission skips for one sample collapse by reason. """
 
         # Designate all-but-one of the failure reasons as the observations.
         for failures in itertools.combinations(
@@ -368,20 +368,18 @@ class RunErrorReportTests:
 
             # Build up the expectations and the input.
             all_skip_reasons = []
-            nskip_by_skip = {}
 
             # Randomize skip/fail count for each reason.
             for skip in failures:
                 n_skip = nprand.randint(low=2, high=5, size=1)[0]
                 all_skip_reasons.extend([skip] * n_skip)
-                nskip_by_skip[skip] = n_skip
 
-            random.shuffle(all_skip_reasons)
             # Aggregation is order-agnostic...
+            random.shuffle(all_skip_reasons)
             original_skip_reasons = [(all_skip_reasons, "control-sample")]
             # ...and maps each reason to pair of sample and count.
-            expected_aggregation = {skip: [("control-sample", n_skip)]
-                                    for skip, n_skip in nskip_by_skip.items()}
+            expected_aggregation = {skip: ["control-sample"]
+                                    for skip in set(all_skip_reasons)}
 
             # Validate.
             observed_aggregation = aggregate_exec_skip_reasons(


### PR DESCRIPTION
Changes in https://github.com/epigen/looper/pull/106 (intentionally) reported submission skip count per-sample for each skip reason. We should instead report simply *that* a sample was skipped for a particular reason, not *how many times* it was skipped for that reason. Furthermore, `continue` statements introduced in https://github.com/epigen/looper/pull/106 caused a lack of aggregation of pipeline-level skip reasons in the submission report. This should bring back the aggregation.