### PR TITLE
Deprecating "library", favoring "protocol"

### DIFF
--- a/looper/looper.py
+++ b/looper/looper.py
@@ -217,7 +217,9 @@ def run(prj, args, remaining_args):
         try:
             _LOGGER.info(_COUNTER.show(sample.sample_name, sample.protocol))
         except AttributeError:
-            print("Sample attributes: {}".format(", ".join(sample.__dict__.keys())))
+            with open("/home/vpr9v/looplog.txt", 'w') as f:
+                for attr in sample.__dict__:
+                    f.write("{}\n".format(attr))
             raise
 
         sample_output_folder = os.path.join(

--- a/looper/looper.py
+++ b/looper/looper.py
@@ -212,7 +212,7 @@ def run(prj, args, remaining_args):
             alpha_cased(p)) for p in prj.protocols}
 
     for sample in prj.samples:
-        _LOGGER.info(_COUNTER.show(sample.sample_name, sample.library))
+        _LOGGER.info(_COUNTER.show(sample.sample_name, sample.protocol))
 
         sample_output_folder = os.path.join(
                 prj.metadata.results_subdir, sample.sample_name)
@@ -230,7 +230,7 @@ def run(prj, args, remaining_args):
 
         # Get the base protocol-to-pipeline mappings
         try:
-            protocol = alpha_cased(sample.library)
+            protocol = alpha_cased(sample.protocol)
         except AttributeError:
             skip_reasons.append("Missing 'library' attribute")
         else:
@@ -476,7 +476,7 @@ def summarize(prj):
     _start_counter(prj.num_samples)
 
     for sample in prj.samples:
-        _LOGGER.info(_COUNTER.show(sample.sample_name, sample.library))
+        _LOGGER.info(_COUNTER.show(sample.sample_name, sample.protocol))
         sample_output_folder = os.path.join(
                 prj.metadata.results_subdir, sample.sample_name)
 
@@ -538,7 +538,7 @@ def destroy(prj, args, preview_flag=True):
     _start_counter(prj.num_samples)
 
     for sample in prj.samples:
-        _LOGGER.info(_COUNTER.show(sample.sample_name, sample.library))
+        _LOGGER.info(_COUNTER.show(sample.sample_name, sample.protocol))
         sample_output_folder = os.path.join(
                 prj.metadata.results_subdir, sample.sample_name)
         if preview_flag:
@@ -575,7 +575,7 @@ def clean(prj, args, preview_flag=True):
     _start_counter(prj.num_samples)
 
     for sample in prj.samples:
-        _LOGGER.info(_COUNTER.show(sample.sample_name, sample.library))
+        _LOGGER.info(_COUNTER.show(sample.sample_name, sample.protocol))
         sample_output_folder = os.path.join(
                 prj.metadata.results_subdir, sample.sample_name)
         cleanup_files = glob.glob(os.path.join(sample_output_folder,

--- a/looper/looper.py
+++ b/looper/looper.py
@@ -212,15 +212,7 @@ def run(prj, args, remaining_args):
             alpha_cased(p)) for p in prj.protocols}
 
     for sample in prj.samples:
-
-        # DEBUG
-        try:
-            _LOGGER.info(_COUNTER.show(sample.sample_name, sample.protocol))
-        except AttributeError:
-            with open("/home/vpr9v/looplog.txt", 'w') as f:
-                for attr in sample.__dict__:
-                    f.write("{}\n".format(attr))
-            raise
+        _LOGGER.info(_COUNTER.show(sample.sample_name, sample.protocol))
 
         sample_output_folder = os.path.join(
                 prj.metadata.results_subdir, sample.sample_name)

--- a/looper/looper.py
+++ b/looper/looper.py
@@ -212,6 +212,7 @@ def run(prj, args, remaining_args):
             alpha_cased(p)) for p in prj.protocols}
 
     for sample in prj.samples:
+        
         _LOGGER.info(_COUNTER.show(sample.sample_name, sample.protocol))
 
         sample_output_folder = os.path.join(
@@ -232,7 +233,7 @@ def run(prj, args, remaining_args):
         try:
             protocol = alpha_cased(sample.protocol)
         except AttributeError:
-            skip_reasons.append("Missing 'library' attribute")
+            skip_reasons.append("Sample has no protocol")
         else:
             protocol = protocol.upper()
             _LOGGER.debug("Fetching submission bundle")
@@ -476,7 +477,12 @@ def summarize(prj):
     _start_counter(prj.num_samples)
 
     for sample in prj.samples:
-        _LOGGER.info(_COUNTER.show(sample.sample_name, sample.protocol))
+        # DEBUG
+        try:
+            _LOGGER.info(_COUNTER.show(sample.sample_name, sample.protocol))
+        except AttributeError:
+            print("Sample attributes: {}".format(", ".join(sample.__dict__.keys())))
+            raise
         sample_output_folder = os.path.join(
                 prj.metadata.results_subdir, sample.sample_name)
 
@@ -618,30 +624,30 @@ class LooperCounter(object):
         self.count = 0
         self.total = total
 
-    def show(self, name, library):
+    def show(self, name, protocol):
         """
-        Display sample counts status for a particular library type.
+        Display sample counts status for a particular protocol type.
          
-        The counts are running vs. total for the library within the Project, 
+        The counts are running vs. total for the protocol within the Project, 
         and as a side-effect of the call, the running count is incremented.
         
         :param str name: name of the sample
-        :param str library: name of the library
+        :param str protocol: name of the protocol
         :return str: message suitable for logging a status update
         """
         self.count += 1
-        return Fore.CYAN + "## [{n} of {N}] {sample} ({library})".format(
-                n=self.count, N=self.total, sample=name, library=library) + \
-               Style.RESET_ALL
+        return _submission_status_text(
+                curr=self.count, total=self.total, sample_name=name,
+                sample_protocol=protocol, color=Fore.CYAN)
 
     def __str__(self):
         return "LooperCounter of size {}".format(self.total)
 
 
-def _submission_status_text(curr, total, sample_name, sample_library):
-    return Fore.BLUE + \
-           "## [{n} of {N}] {sample} ({library})".format(
-                n=curr, N=total, sample=sample_name, library=sample_library) + \
+def _submission_status_text(curr, total, sample_name, sample_protocol, color):
+    return color + \
+           "## [{n} of {N}] {sample} ({protocol})".format(
+                n=curr, N=total, sample=sample_name, protocol=sample_protocol) + \
            Style.RESET_ALL
 
 

--- a/looper/looper.py
+++ b/looper/looper.py
@@ -212,8 +212,13 @@ def run(prj, args, remaining_args):
             alpha_cased(p)) for p in prj.protocols}
 
     for sample in prj.samples:
-        
-        _LOGGER.info(_COUNTER.show(sample.sample_name, sample.protocol))
+
+        # DEBUG
+        try:
+            _LOGGER.info(_COUNTER.show(sample.sample_name, sample.protocol))
+        except AttributeError:
+            print("Sample attributes: {}".format(", ".join(sample.__dict__.keys())))
+            raise
 
         sample_output_folder = os.path.join(
                 prj.metadata.results_subdir, sample.sample_name)
@@ -477,12 +482,7 @@ def summarize(prj):
     _start_counter(prj.num_samples)
 
     for sample in prj.samples:
-        # DEBUG
-        try:
-            _LOGGER.info(_COUNTER.show(sample.sample_name, sample.protocol))
-        except AttributeError:
-            print("Sample attributes: {}".format(", ".join(sample.__dict__.keys())))
-            raise
+        _LOGGER.info(_COUNTER.show(sample.sample_name, sample.protocol))
         sample_output_folder = os.path.join(
                 prj.metadata.results_subdir, sample.sample_name)
 

--- a/looper/models.py
+++ b/looper/models.py
@@ -2302,7 +2302,7 @@ class PipelineInterface(object):
 
         :param pipeline_name: Name of pipeline.
         :type pipeline_name: str
-        :param file_size: Size of input data.
+        :param file_size: Size of input data (in gigabytes).
         :type file_size: float
         :return: resource bundle appropriate for given pipeline,
             for given input file size
@@ -2369,9 +2369,9 @@ class PipelineInterface(object):
         for rp_name, rp_data in resource_packages:
             size_ante = file_size_ante(rp_name, rp_data)
             if file_size >= size_ante:
-                _LOGGER.debug(
-                        "Selected '{}' package with min file size {} for {}.".
-                        format(rp_name, size_ante, file_size))
+                msg = "Selected '{}' package with min file size {} Gb for file " \
+                      "of size {} Gb.".format(rp_name, size_ante, file_size)
+                _LOGGER.debug(msg)
                 return rp_data
 
 

--- a/looper/models.py
+++ b/looper/models.py
@@ -63,6 +63,7 @@ if sys.version_info < (3, 0):
     from urlparse import urlparse
 else:
     from urllib.parse import urlparse
+import warnings
 
 import pandas as _pd
 import yaml
@@ -1703,6 +1704,13 @@ class Sample(object):
 
     @property
     def library(self):
+        """
+        Backwards-compatible alias.
+
+        :return str: The protocol / NGS library name for this Sample.
+        """
+        warnings.warn("Sample 'library' attribute is deprecated; instead, "
+                      "refer to 'protocol'", DeprecationWarning)
         return self.protocol
 
 

--- a/tests/models/integration/test_Project_Sample_interaction.py
+++ b/tests/models/integration/test_Project_Sample_interaction.py
@@ -190,7 +190,7 @@ class BuildSheetTests:
         if protocols:
             fuzzy_protos = {alpha_cased(p) for p in protocols}
             for _, sample_data in sheet.iterrows():
-                assert alpha_cased(sample_data.library) in fuzzy_protos
+                assert alpha_cased(sample_data.protocol) in fuzzy_protos
 
 
 


### PR DESCRIPTION
This maintains compatibility with `library` attribute on `Sample` but represents the same datum as `protocol ` under-the-hood, and references in the code are now to `protocol`.
Close https://github.com/epigen/looper/issues/59
Mild connection to https://github.com/epigen/looper/issues/74