### PR TITLE
Format lists as ordinary messages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
 os:
   - linux
 install:
+  - pip install --upgrade six
   - pip install .
   - pip install -r requirements/requirements-dev.txt
   - pip install -r requirements/requirements-test.txt

--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ Looper supports Python 2.7 only and has been tested only in Linux. To use looper
 looper run project_config.yaml
 ```
 
+
+# Installation troubleshooting
+If you clone this repository and then an attempt at local installation, e.g. with `pip install --upgrade ./`, fails, this may be due to an issue 
+with `setuptools` and `six`. A `FileNotFoundError` (Python 3) or an `IOError` (Python2), with a message/traceback about a nonexist `METADATA` file 
+means that this is even more likely the cause. To get around this, you can `pip install --upgrade six` or `pip install six==1.11.0`, as upgrading 
+from `six` from 1.10.0 to 1.11.0 resolves this issue.
+
+
 # Contributing
 - After adding tests in `tests` for a new feature or a bug fix, please run the test suite.
 - To do so, the only additional dependencies needed beyond those for the package can be 

--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ looper run project_config.yaml
 
 # Installation troubleshooting
 If you clone this repository and then an attempt at local installation, e.g. with `pip install --upgrade ./`, fails, this may be due to an issue 
-with `setuptools` and `six`. A `FileNotFoundError` (Python 3) or an `IOError` (Python2), with a message/traceback about a nonexist `METADATA` file 
-means that this is even more likely the cause. To get around this, you can `pip install --upgrade six` or `pip install six==1.11.0`, as upgrading 
-from `six` from 1.10.0 to 1.11.0 resolves this issue.
+with `setuptools` and `six`. A `FileNotFoundError` (Python 3) or an `IOError` (Python2), with a message/traceback about a nonexistent `METADATA` file 
+means that this is even more likely the cause. To get around this, you can first manually `pip install --upgrade six` or `pip install six==1.11.0`, 
+as upgrading from `six` from 1.10.0 to 1.11.0 resolves this issue, then retry the `looper` installation.
 
 
 # Contributing

--- a/looper/looper.py
+++ b/looper/looper.py
@@ -245,7 +245,7 @@ def run(prj, args, remaining_args):
                 skip_reasons.append("No submission bundle for protocol")
 
         if skip_reasons:
-            _LOGGER.warn("> Not submitted: {}".format(skip_reasons))
+            _LOGGER.warn("> Not submitted: {}".format(", ".join(skip_reasons)))
             failures.append([skip_reasons, sample.sample_name])
             continue
 
@@ -438,9 +438,10 @@ def run(prj, args, remaining_args):
         _LOGGER.info("%d sample(s) with submission failure.", len(failures))
         sample_by_reason = aggregate_exec_skip_reasons(failures)
         _LOGGER.info("{} unique reasons for submission failure: {}".format(
-                len(sample_by_reason),
-                list(sample_by_reason.keys())))
-        _LOGGER.info("Samples by failure: {}".format(dict(sample_by_reason)))
+                len(sample_by_reason), ", ".join(sample_by_reason.keys())))
+        _LOGGER.info("Samples by failure:\n{}".format(
+            "\n".join(["{}: {}".format(failure, ", ".join(samples))
+                       for failure, samples in sample_by_reason.items()])))
 
 
 

--- a/requirements/requirements-all.txt
+++ b/requirements/requirements-all.txt
@@ -1,3 +1,4 @@
 colorama==0.3.9
 pandas>=0.20.2
 pyyaml==3.12
+


### PR DESCRIPTION
Noticed by @nsheff , some of the messages during a `looper run` have funny formatting because the values are list objects; this makes them appear more as ordinary text. These changes also provides help for a potential issue with local installation, that's related to `six` and `setuptools`, and attempts to preempt this problem for the test build.