### PR TITLE
Fix command accounting

### DIFF
--- a/looper/submission_manager.py
+++ b/looper/submission_manager.py
@@ -335,6 +335,7 @@ class SubmissionConductor(object):
             script = self._write_script(settings, prj_argtext=prj_argtext,
                                         looper_argtext=looper_argtext)
 
+            num_cmds = len(self._pool)
             self._num_total_job_submissions += 1
 
             # Determine whether to actually do the submission.
@@ -360,7 +361,7 @@ class SubmissionConductor(object):
             _LOGGER.debug("SUBMITTED")
             submitted = True
             self._num_good_job_submissions += 1
-            self._num_cmds_submitted += len(self._pool)
+            self._num_cmds_submitted += num_cmds
 
             # Reset the command pool.
             self._reset_pool()

--- a/looper/submission_manager.py
+++ b/looper/submission_manager.py
@@ -335,7 +335,6 @@ class SubmissionConductor(object):
             script = self._write_script(settings, prj_argtext=prj_argtext,
                                         looper_argtext=looper_argtext)
 
-            num_cmds = len(self._pool)
             self._num_total_job_submissions += 1
 
             # Determine whether to actually do the submission.
@@ -352,18 +351,15 @@ class SubmissionConductor(object):
                 except subprocess.CalledProcessError:
                     self._failed_sample_names.extend(
                             [s.name for s in self.samples])
-                    raise JobSubmissionException(sub_cmd, script)
-                finally:
                     self._reset_pool()
+                    raise JobSubmissionException(sub_cmd, script)
                 time.sleep(self.delay)
 
             # Update the job and command submission tallies.
             _LOGGER.debug("SUBMITTED")
             submitted = True
             self._num_good_job_submissions += 1
-            self._num_cmds_submitted += num_cmds
-
-            # Reset the command pool.
+            self._num_cmds_submitted += len(self._pool)
             self._reset_pool()
 
         else:


### PR DESCRIPTION
For non-dry-run and successful submissions, commands submitted as part of jobs were not being correctly counted; that count was coming up 0 because of pool resets.